### PR TITLE
Fix personId computed property for Message model

### DIFF
--- a/Source/Message/Message.swift
+++ b/Source/Message/Message.swift
@@ -119,7 +119,7 @@ public struct Message : CustomStringConvertible {
     
     /// The identifier of the person who sent this message.
     public var personId: String? {
-        if let uuid = self.activity.actor?.id {
+        if let uuid = self.activity.actor?.entryUUID {
             return WebexId(type: .people, cluster: WebexId.DEFAULT_CLUSTER_ID, uuid: uuid).base64Id
         }
         return nil


### PR DESCRIPTION
The personId computed property implementation is different in 2.6.0 version comparing to previous one. This PR returns encoded actor UUID same as it was in previous version